### PR TITLE
Ditch include path hack for Arduino >= 1.6.6

### DIFF
--- a/LiquidCrystalNew_SPI.cpp
+++ b/LiquidCrystalNew_SPI.cpp
@@ -17,9 +17,16 @@
 
 #include "LiquidCrystalNew_SPI.h"
 
+#if defined(ARDUINO) && ARDUINO >= 10606
+// Newer Arduino has correct include path set for library to library dependencies
+// See https://stackoverflow.com/a/38978273
+#include <SPI.h>
+#include <mcp23s08.h>
+#else
 #include <../SPI/SPI.h>//this chip needs SPI
 #include <../gpio_expander/mcp23s08.h>//include gpioExpander library
 //https://github.com/sumotoy/gpio_expander
+#endif
 
 
 

--- a/LiquidCrystalNew_SPI.h
+++ b/LiquidCrystalNew_SPI.h
@@ -44,8 +44,16 @@
 #define _LiquidCrystalNew_SPI_h
 
 #include <inttypes.h>
+
+#if defined(ARDUINO) && ARDUINO >= 10606
+// Newer Arduino has correct include path set for library to library dependencies
+// See https://stackoverflow.com/a/38978273
+#include <SPI.h>
+#include <mcp23s08.h>
+#else
 #include <../SPI/SPI.h>//this chip needs SPI
 #include <../gpio_expander/mcp23s08.h>//you need to download gpioExpander library (https://github.com/sumotoy/gpio_expander)
+#endif
 
 #include "HD44780.h"
 

--- a/LiquidCrystalNew_T3TWI.cpp
+++ b/LiquidCrystalNew_T3TWI.cpp
@@ -21,11 +21,21 @@
 
 #include "LiquidCrystalNew_T3TWI.h"
 
+#if defined(ARDUINO) && ARDUINO >= 10606
+// Newer Arduino has correct include path set for library to library dependencies
+// See https://stackoverflow.com/a/38978273
+#if defined(__TEENSY3X__)
+	#include <i2c_t3.h>
+#else
+	#include <Wire.h>
+#endif
+#else
 #if defined(__TEENSY3X__)
 	#include <../i2c_t3/i2c_t3.h>
 #else
 	#include <../Wire/Wire.h>
 #endif
+#endif // defined(ARDUINO) && ARDUINO >= 10606
 
 //1/2 chip with software SPI GPIO (3 wire)
 LiquidCrystalNew_T3TWI::LiquidCrystalNew_T3TWI(const byte adrs,byte pins,byte pullup,byte rate,const byte chip,const byte chipType){

--- a/LiquidCrystalNew_TWI.cpp
+++ b/LiquidCrystalNew_TWI.cpp
@@ -12,7 +12,13 @@
 #endif
 
 #include "LiquidCrystalNew_TWI.h"
+#if defined(ARDUINO) && ARDUINO >= 10606
+// Newer Arduino has correct include path set for library to library dependencies
+// See https://stackoverflow.com/a/38978273
+#include <Wire.h>
+#else
 #include <../Wire/Wire.h>
+#endif
 
 #if !defined(_LCDGPIOPINCONFIG_H_)
 	#include "_configurations/pin_config_default.h"


### PR DESCRIPTION
Arduino 1.6.6 fixes the library-to-library dependency issue so using relative paths is no longer required for Arduino >= 1.6.6 (https://stackoverflow.com/a/38978273). Besides that, using relative paths breaks third-party build systems that use different library directory structure such as PlatformIO (which appends a `_IDxxx` suffix to libraries installed from their library repository).